### PR TITLE
Fixing LLM model name parsing

### DIFF
--- a/src/thoughtflow/llm.py
+++ b/src/thoughtflow/llm.py
@@ -74,9 +74,9 @@ class LLM:
         # Parse model ID and initialize service and model name
         if ':' not in model_id: model_id = 'openai:gpt-4-turbo'
         
-        splitted = model_id.split(':') 
-        self.service = splitted[0]
-        self.model = ''.join(splitted[1:]) 
+        service, model = model_id.split(':', 1)
+        self.service = service
+        self.model = model
         self.api_key = key
         self.api_secret = secret
         self.last_params = {} 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -45,6 +45,13 @@ class TestLLMInitialization:
         assert llm.service == "openai"
         assert llm.model == "gpt-4o-mini"
 
+        # Handle Multiple Colons in Model Name
+        llm = LLM(model_id="ollama:mistral:7b", key="")
+
+        assert llm.service == "ollama"
+        assert llm.model == "mistral:7b"
+
+
     def test_defaults_to_openai_gpt4_when_no_colon(self):
         """
         LLM must default to OpenAI service when no service prefix.
@@ -463,20 +470,6 @@ class TestModelParsing:
     """
     Tests for model string parsing.
     """
-
-    def test_handles_model_with_multiple_colons(self):
-        """
-        Model string with multiple colons should only split on first.
-        
-        Some model names may contain colons (e.g., dates).
-        
-        Remove this test if: We change parsing logic.
-        """
-        llm = LLM(model_id="openai:gpt-4o:extra:part", key="test-key")
-        
-        assert llm.service == "openai"
-        # Model should be everything after first colon
-        assert llm.model == "gpt-4oextrapart"  # Current implementation joins without colons
 
     def test_stores_last_params(self):
         """


### PR DESCRIPTION
Parses model name to include all parts when there is an additional colon

Without fix, can't use model names that have a colon, such as `mistral:7b`

Added another assert to the LLM model parsing init test. Removed other test that "approved" of the behavior.