### PR TITLE
Feature/add get last result

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         entry: hooks/block-ai-contributors.sh message
         language: script
         always_run: true
-        pass_filenames: false
+        pass_filenames: true
         stages: [commit-msg]
 
       - id: ruff-check

--- a/src/thoughtflow/memory.py
+++ b/src/thoughtflow/memory.py
@@ -542,6 +542,23 @@ class MEMORY:
             return '' if content_only else None
         return logs[-1]['content'] if content_only else logs[-1]
 
+    def last_result_msg(self, content_only=False):
+        """
+        Get the last result message.
+        
+        Args:
+            content_only: If True, return just the content string. 
+                          If False (default), return the full event dict.
+
+        Returns:
+            dict or str: Full event dict, or content string if content_only=True.
+                         Returns None (or '' if content_only) if no logs.
+        """
+        msgs = self.get_msgs(include=['result'])
+        if not msgs:
+            return '' if content_only else None
+        return msgs[-1]['content'] if content_only else msgs[-1]
+
     def last_ref(self, content_only=False):
         """
         Get the last reflection.


### PR DESCRIPTION
Adding in a simple method to memory to get last result message. 

Useful when I want to validate that a tool has been used and has received a result. Helps empower a tool run & check feedback loop.

Fixed pre-commit, kept failing with this error:
```
block-ai-trailer.........................................................Failed
- hook id: block-ai-trailer
- exit code: 1

  /Users/cortlandgoffena/Documents/repos/thoughtflow/hooks/block-ai-contributors.sh: line 192: 2: Usage: block-ai-contributors.sh message <file>
```
It needed filename passed to succeed.
